### PR TITLE
Fixes #42 -- better error formatting

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+#### 0.13.1
+- Better error formatting
+
 #### 0.13.0
 - Pull in `@learnersguild/game-cli@0.13.1`
 - Pass a command prefix and max width of 80 to game-cli

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'learnersguild:rocketchat-lg-slash-commands',
-  version: '0.13.0',
+  version: '0.13.1',
   summary: 'Custom /slash commands for Rocket.Chat within Learners Guild.',
   git: 'https://github.com/LearnersGuild/rocketchat-lg-slash-commands'
 })

--- a/server/lib/format.js
+++ b/server/lib/format.js
@@ -7,7 +7,11 @@
 formatUsage = text => `\`\`\`diff\n${text}\`\`\``
 
 formatError = msg => {
-  const formattedText = `**Error:** ${msg.toString()}`  // prefix with bold 'Error:'
-    .replace(/\s\-{1,2}[^\s]+/, '`$&`')                   // show options preformatted
-  return `${formattedText}. Try \`--help\` for usage.`  // append usage suggestion
+  return msg.toString()
+    // ensure prefixed with bold 'Error:'
+    .replace(/(^Error: )?(.*)/, '**Error:** $2')
+    // preformat commands or solo options
+    .replace(/(\W)((\/\w+)(\s+\-{1,2}[\w_-]+)*|\-{1,2}[\w_-]+)/g, '$1`$2`')
+    // make sure nothing got doubly-preformatted
+    .replace(/``/g, '`')
 }

--- a/server/lib/format.js
+++ b/server/lib/format.js
@@ -10,8 +10,4 @@ formatError = msg => {
   return msg.toString()
     // ensure prefixed with bold 'Error:'
     .replace(/(^Error: )?(.*)/, '**Error:** $2')
-    // preformat commands or solo options
-    .replace(/(\W)((\/\w+)(\s+\-{1,2}[\w_-]+)*|\-{1,2}[\w_-]+)/g, '$1`$2`')
-    // make sure nothing got doubly-preformatted
-    .replace(/``/g, '`')
 }


### PR DESCRIPTION
- don't add the `try --help` phrase to the end of all errors
- more robust pre-formatting for commands and options
